### PR TITLE
fix(nslider): convert PDF to image ignoring aspect ratio

### DIFF
--- a/apps/nslider/slides/convert.sh
+++ b/apps/nslider/slides/convert.sh
@@ -2,7 +2,7 @@
 
 convert slides.pdf \
   -sharpen "0x1.0" \
-  -type truecolor -resize 400x300 slides.bmp
+  -type truecolor -resize 400x300\! slides.bmp
 
 mkdir -p $NAVY_HOME/fsimg/share/slides/
 rm $NAVY_HOME/fsimg/share/slides/*


### PR DESCRIPTION
使用`!`标志可以无视原有比例强制改变图片尺寸。
可以让slides.pdf并非严格的4:3时也能生成400x300的图片从而在nslider中获得正常的显示效果。