### PR TITLE
[FIX] add scripts/riscv/common.mk into git track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 !.gitignore
 !*.[cSh]
 !*.cpp
-!scripts/*.mk
+!scripts/**/*.mk
 build/
 repo/
 libs/libc/


### PR DESCRIPTION
Seems that this file isn't appropriately tracked by the git, just inside the repo cache.