### PR TITLE
[FIX]: nplayer/main.c: the problem of incorrectly judging the end of the music.

### DIFF
--- a/apps/nplayer/src/main.c
+++ b/apps/nplayer/src/main.c
@@ -63,7 +63,7 @@ void FillAudio(void *userdata, uint8_t *stream, int len) {
   int nbyte = 0;
   int samples_per_channel = stb_vorbis_get_samples_short_interleaved(v,
       info.channels, (int16_t *)stream, len / sizeof(int16_t));
-  if (samples_per_channel != 0) {
+  if (samples_per_channel != 0 || len < sizeof(int16_t)) {
     int samples = samples_per_channel * info.channels;
     nbyte = samples * sizeof(int16_t);
     AdjustVolume((int16_t *)stream, samples);


### PR DESCRIPTION
`apps/nplayer/src/main.c`: Fix the issue of incorrectly judging the end of the music.

When the callback function is called too frequently (and it is hard to ruler whether or not it is), it's easy for `FillAudio` to get an argument `len` with `len < sizeof(int16_t)`, then `len / sizeof(int16_t)` equals to zero, which leads to going to the branch `is_end=1;`, though in fact this is due to **the argument of `stb_vorbis_get_samples_short_interleaved` is wrongly `num_shorts=0`**.

On my own test, though with the time to call callback function set properly, it is easy for a music with length 05:00 to stop on its 2/3. And I think this needs to be fixed.