### PR TITLE
busybox: scope LINKAGE to repo sub-make during riscv32 builds

### DIFF
--- a/apps/busybox/Makefile
+++ b/apps/busybox/Makefile
@@ -17,7 +17,6 @@ CFLAGS += -I$(WORK_DIR)/include/navy/ -D__GLIBC__ -fdata-sections -ffunction-sec
 comma = ,
 LDFLAGS := $(addprefix -Wl$(comma), $(LDFLAGS))
 export LDFLAGS
-export LINKAGE
 endif
 
 export CFLAGS
@@ -26,16 +25,16 @@ export CROSS_COMPILE
 # The busybox Makefile can not correctly handle the dependency when
 # $(LINKAGE) are updated. If it is the case, perform a fresh build.
 $(APP): force;
-	$(MAKE) -C $(REPO_PATH)
+	$(MAKE) -C $(REPO_PATH) LINKAGE="$(LINKAGE)"
 	cp $(REPO_PATH)/busybox $@
 
 force: ;
 
 menuconfig:
-	$(MAKE) -C $(REPO_PATH) $@
+	$(MAKE) -C $(REPO_PATH) LINKAGE="$(LINKAGE) "$@
 
 install:
-	$(MAKE) -C $(REPO_PATH) CONFIG_PREFIX=$(NAVY_HOME)/fsimg $@
+	$(MAKE) -C $(REPO_PATH) LINKAGE="$(LINKAGE)" CONFIG_PREFIX=$(NAVY_HOME)/fsimg $@
 
 clean: clean-busybox
 


### PR DESCRIPTION
## Summary

This PR fixes a BusyBox-specific recursive build failure in `navy-apps` for `ISA=riscv32`.

The root problem is that `apps/busybox/Makefile` exported the top-level `LINKAGE` variable globally. That caused recursive library builds such as `compiler-rt`, `libc`, and `libos` to inherit BusyBox's app-level link inputs, even though those archive builds should only use their own archive members.

The fix is to stop exporting `LINKAGE` globally and instead pass it only to the BusyBox `repo` sub-make, where it is actually needed for the final BusyBox link.

## Problem

The BusyBox wrapper includes the common `navy-apps/Makefile`, which appends app-level library archives into the top-level `LINKAGE`, including:

- `compiler-rt-riscv32.a`
- `libc-riscv32.a`
- `libos-riscv32.a`

That top-level `LINKAGE` is valid for the final BusyBox app build.

However, the original wrapper exported it globally:

```make
export LINKAGE
```

As a result, recursive library archive builds inherited BusyBox's outer app-level `LINKAGE`.

For example, when `make` entered `libs/compiler-rt`, the child archive build saw not only its own object files, but also BusyBox's app-level library inputs. That polluted the dependency graph and could make `compiler-rt-riscv32.a` incorrectly depend on `libc-riscv32.a`.

On a clean build, this produced failures such as:

```text
# Building compiler-rt-archive [riscv32]
make[1]: *** No rule to make target '.../libc-riscv32.a', needed by '.../compiler-rt-riscv32.a'.  Stop.
```
## Reproduction

From a clean library build state:

```sh
cd navy-apps/libs/compiler-rt && rm -rf build
cd ../libc && rm -rf build
cd ../../apps/busybox
make ISA=riscv32 install
```

Observed failure:

```text
# Building compiler-rt-archive [riscv32]
make[1]: *** No rule to make target '.../libc-riscv32.a', needed by '.../compiler-rt-riscv32.a'.  Stop.
```

If `libc-riscv32.a` is prebuilt from another app directory first, BusyBox may appear to work. That only masks the wrong dependency.


## Root Cause

`LINKAGE` is an app-scoped variable for the final BusyBox link, but it was exported to all recursive sub-makes. That caused archive builds to see BusyBox's outer link inputs even though they should only depend on their own archive members.

## Fix

- remove the global `export LINKAGE`
- pass `LINKAGE` explicitly only to `$(MAKE) -C $(REPO_PATH) ...`

This keeps the final BusyBox link unchanged while preventing recursive library builds from inheriting an unrelated app-level link variable.

